### PR TITLE
#5 add sandbox

### DIFF
--- a/src/stories/sandbox/Text/Text.stories.tsx
+++ b/src/stories/sandbox/Text/Text.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Text from './Text';
+
+export default {
+  title: 'Sandbox/Text',
+  component: Text
+};
+
+export const isError: React.FC<{}> = () => (
+  <div>
+    <Text isError>
+      <p>ホゲホゲホゲホゲ</p>
+    </Text>
+  </div>
+);
+
+export const notError: React.FC<{}> = () => (
+  <div>
+    <Text>
+      <p>ホゲホゲホゲホゲ</p>
+    </Text>
+  </div>
+);

--- a/src/stories/sandbox/Text/Text.tsx
+++ b/src/stories/sandbox/Text/Text.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './text.css';
+
+interface TextProps {
+  children: React.ReactNode;
+  isError?: boolean;
+}
+
+const Text: React.FC<TextProps> = ({
+  children,
+  isError = false
+}: TextProps) => {
+  if (isError) {
+    return (<span className="storybook-text--error">エラーが発生しています。</span>)
+  } else {
+    return (<>{children}</>);
+  }
+};
+
+export default Text;

--- a/src/stories/sandbox/Text/text.css
+++ b/src/stories/sandbox/Text/text.css
@@ -1,0 +1,5 @@
+.storybook-text--error {
+  background-color: #F0F0F0;
+  color: #f00;
+  padding: 1rem;
+}


### PR DESCRIPTION
@tatsuHigh 
正式なコンポーネントディレクトリとは別で、練習用にサンドボックスディレクトリ（ `src/stories/sandbox` ）を追加しました。
この配下は、エラーがでない程度で自由に作ってPRできる環境で、最初のPF練習を行うということでアナウンスして
ButtonとかコピペでPRとかしてもらえたら、コミットの敷居を下げられるかなと。
（練習必要ない人は、普通に  `src/stories/components` に追加してもらう）